### PR TITLE
Publish/2.7.1

### DIFF
--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/holistics/js/issues"
   },
   "dependencies": {
-    "chrono-node": "^1.4.2",
+    "chrono-node": "1.4.8",
     "dayjs": "^1.8.19",
     "lodash": "^4.17.15"
   },

--- a/packages/date-parser/src/index.js
+++ b/packages/date-parser/src/index.js
@@ -4,6 +4,7 @@ import _some from 'lodash/some';
 
 import dayjs from 'dayjs';
 
+// NOTE: order is important to make sure chrono-node uses plugin-enabled dayjs
 import './initializers/dayjs';
 import './initializers/chrono-node';
 

--- a/packages/date-parser/src/index.js
+++ b/packages/date-parser/src/index.js
@@ -53,6 +53,15 @@ const getParsedResultBoundaries = (parsedResults) => {
   return { first, last, hasOrderChanged };
 };
 
+const setDayjsUtcOffset = (parsedResult, timezoneOffset) => {
+  [parsedResult.start, parsedResult.end].forEach((parsedComp) => {
+    const origDayjs = parsedComp.dayjs.bind(parsedComp);
+    parsedComp.dayjs = () => {
+      return origDayjs().utcOffset(timezoneOffset);
+    };
+  });
+};
+
 /**
  * Parse the given date string into Chrono.ParsedResult
  * @param {String} str The date string to parse
@@ -102,6 +111,9 @@ export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.pars
   });
   result.start = first.start.clone();
   result.end = isRangeEndInclusive ? last.end.clone() : last.start.clone();
+
+  // At the beginning, we have adjusted date by timezoneOffset, so now we must set the offset to the end result
+  setDayjsUtcOffset(result, timezoneOffset);
 
   if (output === OUTPUT_TYPES.date) {
     result.start = result.start.moment().format('YYYY-MM-DD');

--- a/packages/date-parser/src/initializers/chrono-node.js
+++ b/packages/date-parser/src/initializers/chrono-node.js
@@ -1,12 +1,27 @@
+import dayjs from 'dayjs';
 import { ParsedComponents } from 'chrono-node';
 
 const overrideDayjs = () => {
-  const origDayjs = ParsedComponents.prototype.dayjs;
+  // Monkey-patch the dayjs function so that the result dayjs object has the plugins that we need (see `./dayjs`).
+  // The function is copied fron chrono-node with no modification
   ParsedComponents.prototype.dayjs = function () {
-    let result = origDayjs.call(this);
-    if (this.get('timezoneOffset') !== undefined) {
-      result = result.utcOffset(this.get('timezoneOffset'));
-    }
+    let result = dayjs();
+
+    result = result.year(this.get('year'));
+    result = result.month(this.get('month') - 1);
+    result = result.date(this.get('day'));
+    result = result.hour(this.get('hour'));
+    result = result.minute(this.get('minute'));
+    result = result.second(this.get('second'));
+    result = result.millisecond(this.get('millisecond'));
+
+    // Javascript Date Object return minus timezone offset
+    const currentTimezoneOffset = result.utcOffset();
+    const targetTimezoneOffset = this.get('timezoneOffset') !== undefined ? this.get('timezoneOffset') : currentTimezoneOffset;
+
+    const adjustTimezoneOffset = targetTimezoneOffset - currentTimezoneOffset;
+    result = result.add(-adjustTimezoneOffset, 'minute');
+
     return result;
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,10 +2848,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chrono-node@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/chrono-node/-/chrono-node-1.4.2.tgz#0c7fc1f264e60a660c2b2dab753a3f285dbfd8c9"
-  integrity sha512-fsb82wPDHVZl3xtche8k4ZZtNwf81/ZMueil2ANpSfogUAEa3BuzZAar7ObLXi1ptMjBzdzA6ys/bFq1oBjO8w==
+chrono-node@1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/chrono-node/-/chrono-node-1.4.8.tgz#10af3f4ed025fa5c6a9abeb7922927584f07f2ef"
+  integrity sha512-WwfW4/+i1e6tHx5opw/VCfxXnai12/tT5GK+wSHwKtdb0ZkAoxRGIfL8IzuFr/JEQTw4DxevysyX6+YbZSRKLQ==
   dependencies:
     dayjs "^1.8.19"
 


### PR DESCRIPTION
## Summary
* Refactor and make sure dayjs is always correctly overridden. 

Explanation: due to non-deterministic build order. Sometimes the `dayjs` lib instance used in `chrono-node` does not have the plugins enabled. Hence `utcOffset` function sometimes returns Number (as in initial funcion definition) instead of Dayjs (as in the utc plugin). So now we re-define `dayjs` function in `initializers/chrono-node` to make sure chrono-node uses the dayjs with plugins enabled

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Breaking change
If this is a breaking change, state the changes.

## Checklist

Please check directly on the box once each of these are done

- [ ] Update CHANGELOG.md
- [ ] Code Review
