### PR TITLE
Date parser/2.8.1

### DIFF
--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [2.8.1](https://github.com/holistics/js/compare/@holistics/date-parser@2.8.0...@holistics/date-parser@2.8.1) (2021-03-16)
+
+**Note:** Version bump only for package @holistics/date-parser

--- a/packages/date-parser/README.md
+++ b/packages/date-parser/README.md
@@ -25,16 +25,16 @@ const timezoneOffset = -(new Date().getTimezoneOffset); // should use the actual
 console.log(parse('3 days from now'), referenceDate, { timezoneOffset });
 // the following examples demonstrate why timezoneOffset is important
 let res;
-res = parse('yesterday', '2019-04-11T22:00:00+00:00', { output: 'date' });
+res = parse('yesterday', '2019-04-11T22:00:00+00:00', { output: OUTPUT_TYPES.date });
 console.log(res.start) // 2019-04-10
 console.log(res.end) // 2019-04-11
-res = parse('yesterday', '2019-04-12T06:00:00+08:00', { output: 'date' });
+res = parse('yesterday', '2019-04-12T06:00:00+08:00', { output: OUTPUT_TYPES.date });
 console.log(res.start) // 2019-04-10
 console.log(res.end) // 2019-04-11
-res = parse('yesterday', '2019-04-11T22:00:00+00:00', { timezoneOffset: 540, output: 'date' });
+res = parse('yesterday', '2019-04-11T22:00:00+00:00', { timezoneOffset: 540, output: OUTPUT_TYPES.date });
 console.log(res.start) // 2019-04-11
 console.log(res.end) // 2019-04-12
 ```
 
 ## Try it out
-https://pns1x.csb.app/
+https://2zs36.csb.app/

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/src/helpers/truncateDateStruct.js
+++ b/packages/date-parser/src/helpers/truncateDateStruct.js
@@ -2,6 +2,7 @@ import _pick from 'lodash/pick';
 
 const DATE_PARTS_FOR_DATE_UNIT = {
   year: ['year'],
+  quarter: ['year', 'month'],
   month: ['year', 'month'],
   week: ['year', 'month', 'day'],
   day: ['year', 'month', 'day'],

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -58,6 +58,24 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-11-01T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-01T00:00:00.000Z');
 
+    res = parse('last quarter', new Date('2019-12-26T02:14:05Z'));
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 7, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 10, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-07-01T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-10-01T00:00:00.000Z');
+
     res = parse('last year', new Date('2020-02-29T02:14:05Z'));
     expect(res).toMatchObject({
       start: {

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -378,11 +378,15 @@ describe('dateParser', () => {
         knownValues: {
           year: 2019, month: 12, day: 1,
         },
-        impliedValues: { hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
       end: {
         knownValues: {},
-        impliedValues: { year: 2019, month: 12, day: 2, hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 2, hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-12-01T00:00:00.000Z');
@@ -394,11 +398,15 @@ describe('dateParser', () => {
         knownValues: {
           year: 2019, month: 12, day: 1,
         },
-        impliedValues: { hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
       end: {
         knownValues: {},
-        impliedValues: { year: 2019, month: 12, day: 2, hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 2, hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-12-01T00:00:00.000Z');
@@ -410,11 +418,15 @@ describe('dateParser', () => {
         knownValues: {
           year: 2019, month: 11, day: 30,
         },
-        impliedValues: { hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
       end: {
         knownValues: {},
-        impliedValues: { year: 2019, month: 11, day: 31, hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 11, day: 31, hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-11-30T00:00:00.000Z');
@@ -430,7 +442,9 @@ describe('dateParser', () => {
       },
       end: {
         knownValues: {},
-        impliedValues: { year: 2019, month: 12, day: 1, hour: 9, minute: 15, second: 33, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 1, hour: 9, minute: 15, second: 33, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-12-01T09:15:32.000Z');
@@ -442,11 +456,15 @@ describe('dateParser', () => {
         knownValues: {
           hour: 19, minute: 15, second: 32,
         },
-        impliedValues: { year: 2019, month: 12, day: 26, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 26, millisecond: 0,
+        },
       },
       end: {
         knownValues: {},
-        impliedValues: { year: 2019, month: 12, day: 26, hour: 19, minute: 15, second: 33, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 26, hour: 19, minute: 15, second: 33, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-12-26T19:15:32.000Z');
@@ -458,11 +476,15 @@ describe('dateParser', () => {
         knownValues: {
           hour: 15, minute: 32,
         },
-        impliedValues: { year: 2019, month: 12, day: 26, second: 0, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 26, second: 0, millisecond: 0,
+        },
       },
       end: {
         knownValues: {},
-        impliedValues: { year: 2019, month: 12, day: 26, hour: 15, minute: 33, second: 0, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 26, hour: 15, minute: 33, second: 0, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-12-26T15:32:00.000Z');
@@ -477,11 +499,15 @@ describe('dateParser', () => {
         knownValues: {
           year: 2019, month: 6,
         },
-        impliedValues: { day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          day: 1, hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
       end: {
         knownValues: {},
-        impliedValues: { year: 2019, month: 7, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 7, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-06-01T00:00:00.000Z');
@@ -493,13 +519,17 @@ describe('dateParser', () => {
         knownValues: {
           year: 2019, month: 1, day: 1,
         },
-        impliedValues: { hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
       end: {
         knownValues: {
           year: 2020, month: 1, day: 1,
         },
-        impliedValues: { hour: 0, minute: 0, second: 0, millisecond: 0 },
+        impliedValues: {
+          hour: 0, minute: 0, second: 0, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-01-01T00:00:00.000Z');
@@ -771,7 +801,9 @@ describe('dateParser', () => {
         knownValues: {
           hour: 15, minute: 36,
         },
-        impliedValues: { year: 2019, month: 12, day: 31, second: 0, millisecond: 0 },
+        impliedValues: {
+          year: 2019, month: 12, day: 31, second: 0, millisecond: 0,
+        },
       },
     });
     expect(res.start.date().toISOString()).toEqual('2019-12-28T00:00:00.000Z');
@@ -779,6 +811,25 @@ describe('dateParser', () => {
 
     // raises error when start > end
     expect(() => parse('tomorrow till 3 days ago', new Date())).toThrowError(/must be before/i);
+
+    // works normally even with timezoneOffset
+    res = parse('2019-12-28T09:00:00.000Z until 2019-12-28T10:00:00.000Z', new Date('2021-03-16T02:14:05Z'), { timezoneOffset: 120 });
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 28, hour: 9, minute: 0, second: 0, millisecond: 0,
+        },
+        impliedValues: {},
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 12, day: 28, hour: 10, minute: 0, second: 0, millisecond: 0,
+        },
+        impliedValues: {},
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-28T09:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-28T10:00:00.000Z');
   });
 
   it('keeps order when date range boundaries overlaps', () => {

--- a/packages/date-parser/src/initializers/dayjs.js
+++ b/packages/date-parser/src/initializers/dayjs.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import en from 'dayjs/locale/en';
 import utcPlugin from 'dayjs/plugin/utc';
 import weekdayPlugin from 'dayjs/plugin/weekday';
+import quarterOfYearPlugin from 'dayjs/plugin/quarterOfYear';
 
 // https://github.com/iamkun/dayjs/issues/215#issuecomment-471280396
 // note that this makes weekday(0) -> monday
@@ -11,3 +12,4 @@ dayjs.locale({
 });
 dayjs.extend(weekdayPlugin);
 dayjs.extend(utcPlugin);
+dayjs.extend(quarterOfYearPlugin);

--- a/packages/date-parser/src/options.js
+++ b/packages/date-parser/src/options.js
@@ -46,8 +46,8 @@ export default {
     new refiner.ENMergeDateRangeRefiner(),
     new refiner.ENPrioritizeSpecificDateRefiner(),
 
-    implier,
     timezoneRefiner,
+    implier,
     ambiguityRefiner,
   ],
 };

--- a/packages/date-parser/src/parsers/lastX.js
+++ b/packages/date-parser/src/parsers/lastX.js
@@ -8,7 +8,7 @@ import isTimeUnit from '../helpers/isTimeUnit';
 const parser = new Chrono.Parser();
 
 parser.pattern = () => {
-  return new RegExp('(last|next|this)( \\d+)? (year|month|week|day|hour|minute|second)s?( (?:begin|end))?', 'i');
+  return new RegExp('(last|next|this)( \\d+)? (year|quarter|month|week|day|hour|minute|second)s?( (?:begin|end))?', 'i');
 };
 
 /**

--- a/packages/date-parser/src/refiners/timezone.js
+++ b/packages/date-parser/src/refiners/timezone.js
@@ -15,8 +15,9 @@ timezoneRefiner.refine = (text, results, { timezoneOffset }) => {
    * @param {Chrono.ParsedResult} res
    */
   return results.map(res => {
-    implyTimezone(res.start, timezoneOffset);
-    implyTimezone(res.end, timezoneOffset);
+    /* istanbul ignore else */
+    if (res.start) implyTimezone(res.start, timezoneOffset);
+    if (res.end) implyTimezone(res.end, timezoneOffset);
     return res;
   });
 };


### PR DESCRIPTION
## Summary
* Bump date parser to 2.8.1
    * fix range end having wrong timezone when parsing iso timestamp
    * support 'quarter' of year

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Breaking change


## Checklist

Please check directly on the box once each of these are done

- [ ] Update CHANGELOG.md
- [ ] Code Review
