### PR TITLE
[Date parser] Expose week start date as a new agrument in date-parser

### DIFF
--- a/packages/date-parser/src/constants.js
+++ b/packages/date-parser/src/constants.js
@@ -9,20 +9,30 @@ export const DATE_UNIT_LEVELS = {
 };
 
 export const WEEKDAYS = {
+  Sunday: 'sunday',
+  Monday: 'monday',
+  Tuesday: 'tuesday',
+  Wednesday: 'wednesday',
+  Thursday: 'thursday',
+  Friday: 'friday',
+  Saturday: 'saturday',
+};
+
+export const WEEKDAYS_MAP = {
   sun: 0,
-  sunday: 0,
+  [WEEKDAYS.Sunday]: 0,
   mon: 1,
-  monday: 1,
+  [WEEKDAYS.Monday]: 1,
   tue: 2,
-  tuesday: 2,
+  [WEEKDAYS.Tuesday]: 2,
   wed: 3,
-  wednesday: 3,
+  [WEEKDAYS.Wednesday]: 3,
   thu: 4,
-  thursday: 4,
+  [WEEKDAYS.Thursday]: 4,
   fri: 5,
-  friday: 5,
+  [WEEKDAYS.Friday]: 5,
   sat: 6,
-  saturday: 6,
+  [WEEKDAYS.Saturday]: 6,
 };
 
 /**

--- a/packages/date-parser/src/constants.js
+++ b/packages/date-parser/src/constants.js
@@ -9,23 +9,6 @@ export const DATE_UNIT_LEVELS = {
 };
 
 export const WEEKDAYS = {
-  mon: 0,
-  monday: 0,
-  tue: 1,
-  tuesday: 1,
-  wed: 2,
-  wednesday: 2,
-  thu: 3,
-  thursday: 3,
-  fri: 4,
-  friday: 4,
-  sat: 5,
-  saturday: 5,
-  sun: 6,
-  sunday: 6,
-};
-
-export const WSD_REMAPPING = {
   sun: 0,
   sunday: 0,
   mon: 1,

--- a/packages/date-parser/src/constants.js
+++ b/packages/date-parser/src/constants.js
@@ -25,6 +25,23 @@ export const WEEKDAYS = {
   sunday: 6,
 };
 
+export const WSD_REMAPPING = {
+  sun: 0,
+  sunday: 0,
+  mon: 1,
+  monday: 1,
+  tue: 2,
+  tuesday: 2,
+  wed: 3,
+  wednesday: 3,
+  thu: 4,
+  thursday: 4,
+  fri: 5,
+  friday: 5,
+  sat: 6,
+  saturday: 6,
+};
+
 /**
  * @enum {String}
  */

--- a/packages/date-parser/src/helpers/momentFromStruct.js
+++ b/packages/date-parser/src/helpers/momentFromStruct.js
@@ -1,6 +1,13 @@
 import dayjs from 'dayjs';
+import en from 'dayjs/locale/en';
 
-export default ({ year, month, day, hour, minute, second }) => {
+export default ({
+  year, month, day, hour, minute, second,
+}, weekStartDate = 1) => {
+  dayjs().locale({
+    ...en,
+    weekStart: weekStartDate,
+  });
   return dayjs.utc()
     .year(year)
     .month(month)

--- a/packages/date-parser/src/helpers/momentFromStruct.js
+++ b/packages/date-parser/src/helpers/momentFromStruct.js
@@ -3,16 +3,24 @@ import en from 'dayjs/locale/en';
 
 export default ({
   year, month, day, hour, minute, second,
-}, weekStartDate = 1) => {
-  dayjs().locale({
-    ...en,
-    weekStart: weekStartDate,
-  });
+}, {
+  weekStartDate,
+}) => {
+  /* eslint-disable-next-line no-param-reassign */
+  weekStartDate = parseInt(weekStartDate);
+  if (Number.isNaN(weekStartDate) || weekStartDate < 0 || weekStartDate > 6) {
+    throw new Error(`Invalid weekStartDate index: ${weekStartDate}`);
+  }
+
   return dayjs.utc()
     .year(year)
     .month(month)
     .date(day)
     .hour(hour)
     .minute(minute)
-    .second(second);
+    .second(second)
+    .locale({
+      ...en,
+      weekStart: weekStartDate,
+    });
 };

--- a/packages/date-parser/src/helpers/momentFromStruct.test.js
+++ b/packages/date-parser/src/helpers/momentFromStruct.test.js
@@ -1,0 +1,11 @@
+import momentFromStruct from './momentFromStruct';
+
+describe('momentFromStruct', () => {
+  it('validates weekStartDate', () => {
+    expect(() => momentFromStruct({}, { weekStartDate: undefined })).toThrowError(/invalid weekStartDate/i);
+    expect(() => momentFromStruct({}, { weekStartDate: null })).toThrowError(/invalid weekStartDate/i);
+    expect(() => momentFromStruct({}, {})).toThrowError(/invalid weekStartDate/i);
+    expect(() => momentFromStruct({}, { weekStartDate: -1 })).toThrowError(/invalid weekStartDate/i);
+    expect(() => momentFromStruct({}, { weekStartDate: 7 })).toThrowError(/invalid weekStartDate/i);
+  });
+});

--- a/packages/date-parser/src/index.js
+++ b/packages/date-parser/src/index.js
@@ -62,7 +62,7 @@ const getParsedResultBoundaries = (parsedResults) => {
  * @param {Object} options
  * @param {Number} options.timezoneOffset Timezone offset in minutes
  * @param {OUTPUT_TYPES} options.output Type of the output dates
- * @param {Number} weekStartDate Default weekStartDate is 1 (Monday)
+ * @param {Number} weekStartDate Default weekStartDate is 1. 0 = Sunday, 1 = Monday, ..., 6 = Saturday
  * @return {ChronoNode.ParsedResult|Array}
  */
 export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component } = {}, weekStartDate = 1) => {

--- a/packages/date-parser/src/index.js
+++ b/packages/date-parser/src/index.js
@@ -3,7 +3,6 @@ import _compact from 'lodash/compact';
 import _some from 'lodash/some';
 
 import dayjs from 'dayjs';
-import en from 'dayjs/locale/en';
 
 // NOTE: order is important to make sure chrono-node uses plugin-enabled dayjs
 import './initializers/dayjs';
@@ -66,11 +65,6 @@ const getParsedResultBoundaries = (parsedResults) => {
  * @return {ChronoNode.ParsedResult|Array}
  */
 export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component } = {}, weekStartDate = 1) => {
-  dayjs.locale({
-    ...en,
-    weekStart: weekStartDate,
-  });
-
   const refDate = new Date(ref);
   if (!isValidDate(refDate)) throw new InputError(`Invalid reference date: ${ref}`);
 
@@ -87,7 +81,7 @@ export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.pars
   const { parts, rangeSeparator } = splittedInput;
   let { isRange, isRangeEndInclusive } = splittedInput;
 
-  const parsedResults = _compact(parts.map(part => chrono.parse(part, refDateAdjustedByTz, { timezoneOffset })[0]));
+  const parsedResults = _compact(parts.map(part => chrono.parse(part, refDateAdjustedByTz, { timezoneOffset, weekStartDate })[0]));
 
   if (output === OUTPUT_TYPES.raw) return parsedResults;
 

--- a/packages/date-parser/src/index.js
+++ b/packages/date-parser/src/index.js
@@ -3,6 +3,7 @@ import _compact from 'lodash/compact';
 import _some from 'lodash/some';
 
 import dayjs from 'dayjs';
+import en from 'dayjs/locale/en';
 
 // NOTE: order is important to make sure chrono-node uses plugin-enabled dayjs
 import './initializers/dayjs';
@@ -61,9 +62,15 @@ const getParsedResultBoundaries = (parsedResults) => {
  * @param {Object} options
  * @param {Number} options.timezoneOffset Timezone offset in minutes
  * @param {OUTPUT_TYPES} options.output Type of the output dates
+ * @param {Number} weekStartDate Default weekStartDate is 1 (Monday)
  * @return {ChronoNode.ParsedResult|Array}
  */
-export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component } = {}) => {
+export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component } = {}, weekStartDate = 1) => {
+  dayjs.locale({
+    ...en,
+    weekStart: weekStartDate,
+  });
+
   const refDate = new Date(ref);
   if (!isValidDate(refDate)) throw new InputError(`Invalid reference date: ${ref}`);
 

--- a/packages/date-parser/src/index.js
+++ b/packages/date-parser/src/index.js
@@ -10,7 +10,13 @@ import './initializers/chrono-node';
 
 import options from './options';
 import isValidDate from './helpers/isValidDate';
-import { OUTPUT_TYPES, DATE_RANGE_PATTERNS, DATE_RANGE_KEYWORDS } from './constants';
+import {
+  WEEKDAYS,
+  WEEKDAYS_MAP,
+  OUTPUT_TYPES,
+  DATE_RANGE_PATTERNS,
+  DATE_RANGE_KEYWORDS,
+} from './constants';
 import Errors, { InputError } from './errors';
 
 const chrono = new ChronoNode.Chrono(options);
@@ -61,16 +67,20 @@ const getParsedResultBoundaries = (parsedResults) => {
  * @param {Object} options
  * @param {Number} options.timezoneOffset Timezone offset in minutes
  * @param {OUTPUT_TYPES} options.output Type of the output dates
- * @param {Number} weekStartDate Default weekStartDate is 1. 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+ * @param {Number} weekStartDate The weekday chosen to be the start of a week. See WEEKDAYS constant for possible values
  * @return {ChronoNode.ParsedResult|Array}
  */
-export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component } = {}, weekStartDate = 1) => {
+export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component, weekStartDate = WEEKDAYS.Monday } = {}) => {
   const refDate = new Date(ref);
   if (!isValidDate(refDate)) throw new InputError(`Invalid reference date: ${ref}`);
 
   /* eslint-disable-next-line no-param-reassign */
   timezoneOffset = parseInt(timezoneOffset);
   if (Number.isNaN(timezoneOffset)) throw new InputError(`Invalid timezoneOffset: ${timezoneOffset}`);
+
+  if (!(weekStartDate in WEEKDAYS_MAP)) throw new InputError(`Invalid weekStartDate: ${weekStartDate}. See exported constant WEEKDAYS for valid values`);
+  /* eslint-disable-next-line no-param-reassign */
+  weekStartDate = WEEKDAYS_MAP[weekStartDate];
 
   // Adjust refDate by timezoneOffset
   let refMoment = dayjs.utc(refDate);
@@ -116,11 +126,12 @@ export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.pars
   return result;
 };
 
-export { OUTPUT_TYPES } from './constants';
+export { WEEKDAYS, OUTPUT_TYPES } from './constants';
 export { default as Errors } from './errors';
 
 export default {
   parse,
+  WEEKDAYS,
   OUTPUT_TYPES,
   Errors,
 };

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -1265,18 +1265,54 @@ describe('dateParser', () => {
     expect(res).toMatchObject({
       start: {
         knownValues: {
-          year: 2020, month: 1, day: 4, hour: 0, minute: 0, second: 0,
+          year: 2019, month: 12, day: 28, hour: 0, minute: 0, second: 0,
         },
         impliedValues: { millisecond: 0 },
       },
       end: {
         knownValues: {
-          year: 2020, month: 1, day: 5, hour: 0, minute: 0, second: 0,
+          year: 2019, month: 12, day: 29, hour: 0, minute: 0, second: 0,
         },
         impliedValues: { millisecond: 0 },
       },
     });
-    expect(res.start.date().toISOString()).toEqual('2020-01-04T00:00:00.000Z');
-    expect(res.end.date().toISOString()).toEqual('2020-01-05T00:00:00.000Z');
+    expect(res.start.date().toISOString()).toEqual('2019-12-28T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-29T00:00:00.000Z');
+
+    res = parse('thu next week', new Date('2019-12-26T02:14:05Z'), {}, 4);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2020, month: 1, day: 2, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 3, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2020-01-02T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-03T00:00:00.000Z');
+
+    res = parse('thu last week', new Date('2019-12-26T02:14:05Z'), {}, 4);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 19, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 12, day: 20, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-19T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-20T00:00:00.000Z');
   });
 });

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -239,84 +239,6 @@ describe('dateParser', () => {
     expect(res.end.date().toISOString()).toEqual('2019-12-26T01:17:00.000Z');
   });
 
-  it('works with lastX format and week start date is wednesday', () => {
-    let res;
-
-    res = parse('last week', new Date('2019-12-26T02:14:05Z'), {}, 3);
-    expect(res).toMatchObject({
-      start: {
-        knownValues: {
-          year: 2019, month: 12, day: 18, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-      end: {
-        knownValues: {
-          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-    });
-    expect(res.start.date().toISOString()).toEqual('2019-12-18T00:00:00.000Z');
-    expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
-
-    res = parse('this week', new Date('2019-12-26T02:14:05Z'), {}, 3);
-    expect(res).toMatchObject({
-      start: {
-        knownValues: {
-          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-      end: {
-        knownValues: {
-          year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-    });
-    expect(res.start.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
-    expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
-
-    // This test to make sure the WSD does not effect last month
-    res = parse('last 2 month', new Date('2019-02-09T02:14:05Z'), {}, 3);
-    expect(res).toMatchObject({
-      start: {
-        knownValues: {
-          year: 2018, month: 12, day: 1, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-      end: {
-        knownValues: {
-          year: 2019, month: 2, day: 1, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-    });
-    expect(res.start.date().toISOString()).toEqual('2018-12-01T00:00:00.000Z');
-    expect(res.end.date().toISOString()).toEqual('2019-02-01T00:00:00.000Z');
-
-    // This test to make sure the WSD does not effect the last year
-    res = parse('last year', new Date('2020-02-29T02:14:05Z'), {}, 3);
-    expect(res).toMatchObject({
-      start: {
-        knownValues: {
-          year: 2019, month: 1, day: 1, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-      end: {
-        knownValues: {
-          year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0,
-        },
-        impliedValues: { millisecond: 0 },
-      },
-    });
-    expect(res.start.date().toISOString()).toEqual('2019-01-01T00:00:00.000Z');
-    expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
-  });
-
   it('works with xAgo format', () => {
     let res;
 
@@ -1152,5 +1074,119 @@ describe('dateParser', () => {
     expect(() => parse('last monday', new Date())).toThrowError(/ambiguous.*monday last week/i);
     expect(() => parse('next Friday', new Date())).toThrowError(/ambiguous.*Friday next week/);
     expect(() => parse('thursday', new Date())).toThrowError(/ambiguous.*thursday last\/this\/next week/);
+  });
+
+  it('works with week start date', () => {
+    let res;
+
+    res = parse('last week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 18, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-18T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
+
+    res = parse('last 2 weeks', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 11, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-11T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
+
+    res = parse('2 weeks from now', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2020, month: 1, day: 9, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 16, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2020-01-09T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-16T00:00:00.000Z');
+
+    res = parse('this week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
+
+    // This test to make sure the WSD does not effect last month
+    res = parse('last 2 month', new Date('2019-02-09T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2018, month: 12, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 2, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2018-12-01T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-02-01T00:00:00.000Z');
+
+    // This test to make sure the WSD does not effect the last year
+    res = parse('last year', new Date('2020-02-29T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 1, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-01-01T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
   });
 });

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -239,6 +239,84 @@ describe('dateParser', () => {
     expect(res.end.date().toISOString()).toEqual('2019-12-26T01:17:00.000Z');
   });
 
+  it('works with lastX format and week start date is wednesday', () => {
+    let res;
+
+    res = parse('last week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 18, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-18T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
+
+    res = parse('this week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
+
+    // This test to make sure the WSD does not effect last month
+    res = parse('last 2 month', new Date('2019-02-09T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2018, month: 12, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 2, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2018-12-01T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-02-01T00:00:00.000Z');
+
+    // This test to make sure the WSD does not effect the last year
+    res = parse('last year', new Date('2020-02-29T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 1, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 1, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-01-01T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
+  });
+
   it('works with xAgo format', () => {
     let res;
 

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -1188,5 +1188,95 @@ describe('dateParser', () => {
     });
     expect(res.start.date().toISOString()).toEqual('2019-01-01T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
+
+    res = parse('tue last week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 24, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 12, day: 25, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-24T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
+
+    res = parse('tue next 2 weeks', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2020, month: 1, day: 14, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 15, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2020-01-14T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-15T00:00:00.000Z');
+
+    res = parse('mon next week', new Date('2019-12-26T02:14:05Z'), {}, 0);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2019, month: 12, day: 30, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2019, month: 12, day: 31, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2019-12-30T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2019-12-31T00:00:00.000Z');
+
+    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), {}, 0);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2020, month: 1, day: 4, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 5, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2020-01-04T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-05T00:00:00.000Z');
+
+    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), {}, 6);
+    expect(res).toMatchObject({
+      start: {
+        knownValues: {
+          year: 2020, month: 1, day: 4, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+      end: {
+        knownValues: {
+          year: 2020, month: 1, day: 5, hour: 0, minute: 0, second: 0,
+        },
+        impliedValues: { millisecond: 0 },
+      },
+    });
+    expect(res.start.date().toISOString()).toEqual('2020-01-04T00:00:00.000Z');
+    expect(res.end.date().toISOString()).toEqual('2020-01-05T00:00:00.000Z');
   });
 });

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -1,4 +1,6 @@
-import { parse, OUTPUT_TYPES, Errors } from './index';
+import {
+  parse, WEEKDAYS, OUTPUT_TYPES, Errors,
+} from './index';
 
 describe('dateParser', () => {
   it('works with lastX format', () => {
@@ -1076,10 +1078,10 @@ describe('dateParser', () => {
     expect(() => parse('thursday', new Date())).toThrowError(/ambiguous.*thursday last\/this\/next week/);
   });
 
-  it('works with week start date', () => {
+  it('works with weekStartDate', () => {
     let res;
 
-    res = parse('last week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    res = parse('last week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1097,7 +1099,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-18T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
 
-    res = parse('last 2 weeks', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    res = parse('last 2 weeks', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1115,7 +1117,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-11T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
 
-    res = parse('2 weeks from now', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    res = parse('2 weeks from now', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1133,7 +1135,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-09T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-16T00:00:00.000Z');
 
-    res = parse('this week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    res = parse('this week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1152,7 +1154,7 @@ describe('dateParser', () => {
     expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
 
     // This test to make sure the WSD does not effect last month
-    res = parse('last 2 month', new Date('2019-02-09T02:14:05Z'), {}, 3);
+    res = parse('last 2 month', new Date('2019-02-09T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1171,7 +1173,7 @@ describe('dateParser', () => {
     expect(res.end.date().toISOString()).toEqual('2019-02-01T00:00:00.000Z');
 
     // This test to make sure the WSD does not effect the last year
-    res = parse('last year', new Date('2020-02-29T02:14:05Z'), {}, 3);
+    res = parse('last year', new Date('2020-02-29T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1189,7 +1191,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-01-01T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
 
-    res = parse('tue last week', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    res = parse('tue last week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1207,7 +1209,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-24T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
 
-    res = parse('tue next 2 weeks', new Date('2019-12-26T02:14:05Z'), {}, 3);
+    res = parse('tue next 2 weeks', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1225,7 +1227,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-14T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-15T00:00:00.000Z');
 
-    res = parse('mon next week', new Date('2019-12-26T02:14:05Z'), {}, 0);
+    res = parse('mon next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Sunday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1243,7 +1245,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-30T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-31T00:00:00.000Z');
 
-    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), {}, 0);
+    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Sunday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1261,7 +1263,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-04T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-05T00:00:00.000Z');
 
-    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), {}, 6);
+    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Saturday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1279,7 +1281,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-28T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-29T00:00:00.000Z');
 
-    res = parse('thu next week', new Date('2019-12-26T02:14:05Z'), {}, 4);
+    res = parse('thu next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Thursday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1297,7 +1299,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-02T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-03T00:00:00.000Z');
 
-    res = parse('thu last week', new Date('2019-12-26T02:14:05Z'), {}, 4);
+    res = parse('thu last week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Friday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1314,5 +1316,9 @@ describe('dateParser', () => {
     });
     expect(res.start.date().toISOString()).toEqual('2019-12-19T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-20T00:00:00.000Z');
+  });
+
+  it('raises error when weekStartDate is invalid', () => {
+    expect(() => parse('this mon', new Date(), { weekStartDate: 'ahihi' })).toThrowError(/invalid weekStartDate/i);
   });
 });

--- a/packages/date-parser/src/initializers/dayjs.js
+++ b/packages/date-parser/src/initializers/dayjs.js
@@ -4,8 +4,6 @@ import utcPlugin from 'dayjs/plugin/utc';
 import weekdayPlugin from 'dayjs/plugin/weekday';
 import quarterOfYearPlugin from 'dayjs/plugin/quarterOfYear';
 
-// https://github.com/iamkun/dayjs/issues/215#issuecomment-471280396
-// note that this makes weekday(0) -> monday
 dayjs.locale({
   ...en,
 });

--- a/packages/date-parser/src/initializers/dayjs.js
+++ b/packages/date-parser/src/initializers/dayjs.js
@@ -1,15 +1,10 @@
 import dayjs from 'dayjs';
-import en from 'dayjs/locale/en';
 import utcPlugin from 'dayjs/plugin/utc';
 import weekdayPlugin from 'dayjs/plugin/weekday';
 import quarterOfYearPlugin from 'dayjs/plugin/quarterOfYear';
 
 // https://github.com/iamkun/dayjs/issues/215#issuecomment-471280396
 // note that this makes weekday(0) -> monday
-dayjs.locale({
-  ...en,
-  weekStart: 1,
-});
 dayjs.extend(weekdayPlugin);
 dayjs.extend(utcPlugin);
 dayjs.extend(quarterOfYearPlugin);

--- a/packages/date-parser/src/initializers/dayjs.js
+++ b/packages/date-parser/src/initializers/dayjs.js
@@ -1,10 +1,15 @@
 import dayjs from 'dayjs';
+import en from 'dayjs/locale/en';
 import utcPlugin from 'dayjs/plugin/utc';
 import weekdayPlugin from 'dayjs/plugin/weekday';
 import quarterOfYearPlugin from 'dayjs/plugin/quarterOfYear';
 
 // https://github.com/iamkun/dayjs/issues/215#issuecomment-471280396
 // note that this makes weekday(0) -> monday
+dayjs.locale({
+  ...en,
+  weekStart: 0,
+});
 dayjs.extend(weekdayPlugin);
 dayjs.extend(utcPlugin);
 dayjs.extend(quarterOfYearPlugin);

--- a/packages/date-parser/src/initializers/dayjs.js
+++ b/packages/date-parser/src/initializers/dayjs.js
@@ -8,7 +8,6 @@ import quarterOfYearPlugin from 'dayjs/plugin/quarterOfYear';
 // note that this makes weekday(0) -> monday
 dayjs.locale({
   ...en,
-  weekStart: 0,
 });
 dayjs.extend(weekdayPlugin);
 dayjs.extend(utcPlugin);

--- a/packages/date-parser/src/parsers/guards/ambiguousWeekday.js
+++ b/packages/date-parser/src/parsers/guards/ambiguousWeekday.js
@@ -1,11 +1,11 @@
 import Chrono from 'chrono-node';
-import { WEEKDAYS } from '../../constants';
+import { WEEKDAYS_MAP } from '../../constants';
 import { ParseError } from '../../errors';
 
 const guard = new Chrono.Parser();
 
 guard.pattern = () => {
-  return new RegExp(`^\\s*((?:last|this|next) )?(${Object.keys(WEEKDAYS).join('|')})\\s*$`, 'i');
+  return new RegExp(`^\\s*((?:last|this|next) )?(${Object.keys(WEEKDAYS_MAP).join('|')})\\s*$`, 'i');
 };
 
 /**

--- a/packages/date-parser/src/parsers/lastX.js
+++ b/packages/date-parser/src/parsers/lastX.js
@@ -25,7 +25,7 @@ parser.extract = (text, ref, match, opt) => {
   const pointOfTime = (match[4] || '').trim();
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), dateUnit);
-  let startMoment = momentFromStruct(refDateStruct, weekStartDate);
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDate });
   let endMoment = startMoment.clone();
 
   // Set range according to past/future relativity

--- a/packages/date-parser/src/parsers/lastX.js
+++ b/packages/date-parser/src/parsers/lastX.js
@@ -15,15 +15,17 @@ parser.pattern = () => {
  * @param {String} text
  * @param {Date} ref
  * @param {Array} match
+ * @param {Object} opt
  */
-parser.extract = (text, ref, match) => {
+parser.extract = (text, ref, match, opt) => {
+  const { weekStartDate } = opt;
   const modifier = match[1];
   const value = modifier === 'this' ? 0 : parseInt((match[2] || '1').trim());
   const dateUnit = match[3].toLowerCase();
   const pointOfTime = (match[4] || '').trim();
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), dateUnit);
-  let startMoment = momentFromStruct(refDateStruct);
+  let startMoment = momentFromStruct(refDateStruct, weekStartDate);
   let endMoment = startMoment.clone();
 
   // Set range according to past/future relativity

--- a/packages/date-parser/src/parsers/today.js
+++ b/packages/date-parser/src/parsers/today.js
@@ -15,7 +15,7 @@ parser.pattern = () => {
  * @param {Date} ref
  * @param {Array} match
  */
-parser.extract = (text, ref, match) => {
+parser.extract = (text, ref, match, opt) => {
   const date = match[1].toLowerCase();
   let value = 0;
   if (date === 'yesterday') {
@@ -25,7 +25,7 @@ parser.extract = (text, ref, match) => {
   }
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), 'day');
-  let startMoment = momentFromStruct(refDateStruct);
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDate: opt.weekStartDate });
   startMoment = startMoment.add(value, 'day');
 
   const endMoment = startMoment.add(1, 'day');

--- a/packages/date-parser/src/parsers/weekday.js
+++ b/packages/date-parser/src/parsers/weekday.js
@@ -3,7 +3,7 @@ import dateStructFromDate from '../helpers/dateStructFromDate';
 import truncateDateStruct from '../helpers/truncateDateStruct';
 import momentFromStruct from '../helpers/momentFromStruct';
 import chronoDateStructFromMoment from '../helpers/chronoDateStructFromMoment';
-import { WEEKDAYS, WSD_REMAPPING } from '../constants';
+import { WEEKDAYS } from '../constants';
 
 const parser = new Chrono.Parser();
 
@@ -19,7 +19,6 @@ parser.pattern = () => {
  * @param {Object} opt
  */
 parser.extract = (text, ref, match, opt) => {
-  // We manually handle this case instead of using the wsd
   const { weekStartDate } = opt;
   const weekday = match[1].toLowerCase();
   const modifier = match[2];
@@ -33,12 +32,9 @@ parser.extract = (text, ref, match, opt) => {
   }
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), 'day');
-  let startMoment = momentFromStruct(refDateStruct, 1);
-  if (startMoment.day() > weekStartDate && weekStartDate > WSD_REMAPPING[weekday]) {
-    startMoment = startMoment.add(7, 'days');
-  }
+  let startMoment = momentFromStruct(refDateStruct, weekStartDate);
   startMoment = startMoment.add(value, 'week');
-  startMoment = startMoment.weekday(WEEKDAYS[weekday]);
+  startMoment = startMoment.weekday((7 + WEEKDAYS[weekday] - weekStartDate) % 7);
 
   const endMoment = startMoment.add(1, 'day');
 

--- a/packages/date-parser/src/parsers/weekday.js
+++ b/packages/date-parser/src/parsers/weekday.js
@@ -3,13 +3,13 @@ import dateStructFromDate from '../helpers/dateStructFromDate';
 import truncateDateStruct from '../helpers/truncateDateStruct';
 import momentFromStruct from '../helpers/momentFromStruct';
 import chronoDateStructFromMoment from '../helpers/chronoDateStructFromMoment';
-import { WEEKDAYS } from '../constants';
+import { WEEKDAYS_MAP } from '../constants';
 
 const parser = new Chrono.Parser();
 
 parser.pattern = () => {
   /* eslint-disable-next-line max-len */
-  return new RegExp(`(${Object.keys(WEEKDAYS).join('|')}) (last|this|next)( \\d+)? weeks?`, 'i');
+  return new RegExp(`(${Object.keys(WEEKDAYS_MAP).join('|')}) (last|this|next)( \\d+)? weeks?`, 'i');
 };
 
 /**
@@ -32,9 +32,9 @@ parser.extract = (text, ref, match, opt) => {
   }
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), 'day');
-  let startMoment = momentFromStruct(refDateStruct, weekStartDate);
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDate });
   startMoment = startMoment.add(value, 'week');
-  startMoment = startMoment.weekday((7 + WEEKDAYS[weekday] - weekStartDate) % 7);
+  startMoment = startMoment.weekday((7 + WEEKDAYS_MAP[weekday] - weekStartDate) % 7);
 
   const endMoment = startMoment.add(1, 'day');
 

--- a/packages/date-parser/src/parsers/weekday.js
+++ b/packages/date-parser/src/parsers/weekday.js
@@ -3,7 +3,7 @@ import dateStructFromDate from '../helpers/dateStructFromDate';
 import truncateDateStruct from '../helpers/truncateDateStruct';
 import momentFromStruct from '../helpers/momentFromStruct';
 import chronoDateStructFromMoment from '../helpers/chronoDateStructFromMoment';
-import { WEEKDAYS } from '../constants';
+import { WEEKDAYS, WSD_REMAPPING } from '../constants';
 
 const parser = new Chrono.Parser();
 
@@ -16,8 +16,11 @@ parser.pattern = () => {
  * @param {String} text
  * @param {Date} ref
  * @param {Array} match
+ * @param {Object} opt
  */
-parser.extract = (text, ref, match) => {
+parser.extract = (text, ref, match, opt) => {
+  // We manually handle this case instead of using the wsd
+  const { weekStartDate } = opt;
   const weekday = match[1].toLowerCase();
   const modifier = match[2];
   let value;
@@ -30,7 +33,10 @@ parser.extract = (text, ref, match) => {
   }
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), 'day');
-  let startMoment = momentFromStruct(refDateStruct);
+  let startMoment = momentFromStruct(refDateStruct, 1);
+  if (startMoment.day() > weekStartDate && weekStartDate > WSD_REMAPPING[weekday]) {
+    startMoment = startMoment.add(7, 'days');
+  }
   startMoment = startMoment.add(value, 'week');
   startMoment = startMoment.weekday(WEEKDAYS[weekday]);
 

--- a/packages/date-parser/src/parsers/xAgo.js
+++ b/packages/date-parser/src/parsers/xAgo.js
@@ -16,7 +16,7 @@ parser.pattern = () => {
  * @param {Date} ref
  * @param {Array} match
  */
-parser.extract = (text, ref, match) => {
+parser.extract = (text, ref, match, opt) => {
   const exact = !!match[1];
   const dateUnit = match[3].toLowerCase();
   const isPast = match[4] !== 'from now';
@@ -27,7 +27,7 @@ parser.extract = (text, ref, match) => {
   if (!exact) {
     refDateStruct = truncateDateStruct(refDateStruct, dateUnit);
   }
-  let startMoment = momentFromStruct(refDateStruct);
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDate: opt.weekStartDate });
   startMoment = startMoment.add(value, dateUnit);
 
   let endMoment = startMoment.clone();


### PR DESCRIPTION
## Summary
Expose week start date as a new argument in date-parser
* Move the dayjs.locale config inside momentFromStruct
* Update codes in `lastX` parser and `weekday` parser to support WSD
* Add unit tests to cover week start date cases

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Breaking change
If this is a breaking change, state the changes.

## Checklist

Please check directly on the box once each of these are done

- [ ] Update CHANGELOG.md
- [ ] Code Review
