### PR TITLE
chore!: rename weekStartDate to weekStartDay

### DIFF
--- a/packages/date-parser/README.md
+++ b/packages/date-parser/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ```javascript
-import { parse, OUTPUT_TYPES } from '@holistics/date-parser';
+import { parse, OUTPUT_TYPES, WEEKDAYS } from '@holistics/date-parser';
 
 const referenceDate = new Date();
 
@@ -34,7 +34,11 @@ console.log(res.end) // 2019-04-11
 res = parse('yesterday', '2019-04-11T22:00:00+00:00', { timezoneOffset: 540, output: OUTPUT_TYPES.date });
 console.log(res.start) // 2019-04-11
 console.log(res.end) // 2019-04-12
+
+// Set weekStartDay (weekStartDay is Monday by default)
+res = parse('last week begin', '2021-05-10T22:14:05Z', { weekStartDay: WEEKDAYS.Tuesday, output: OUTPUT_TYPES.date });
+console.log(res.start) // 2021-04-27
 ```
 
 ## Try it out
-https://2zs36.csb.app/
+https://uho5b.csb.app/

--- a/packages/date-parser/src/helpers/momentFromStruct.js
+++ b/packages/date-parser/src/helpers/momentFromStruct.js
@@ -4,12 +4,12 @@ import en from 'dayjs/locale/en';
 export default ({
   year, month, day, hour, minute, second,
 }, {
-  weekStartDate,
+  weekStartDay,
 }) => {
   /* eslint-disable-next-line no-param-reassign */
-  weekStartDate = parseInt(weekStartDate);
-  if (Number.isNaN(weekStartDate) || weekStartDate < 0 || weekStartDate > 6) {
-    throw new Error(`Invalid weekStartDate index: ${weekStartDate}`);
+  weekStartDay = parseInt(weekStartDay);
+  if (Number.isNaN(weekStartDay) || weekStartDay < 0 || weekStartDay > 6) {
+    throw new Error(`Invalid weekStartDay index: ${weekStartDay}`);
   }
 
   return dayjs.utc()
@@ -21,6 +21,6 @@ export default ({
     .second(second)
     .locale({
       ...en,
-      weekStart: weekStartDate,
+      weekStart: weekStartDay,
     });
 };

--- a/packages/date-parser/src/helpers/momentFromStruct.test.js
+++ b/packages/date-parser/src/helpers/momentFromStruct.test.js
@@ -1,11 +1,11 @@
 import momentFromStruct from './momentFromStruct';
 
 describe('momentFromStruct', () => {
-  it('validates weekStartDate', () => {
-    expect(() => momentFromStruct({}, { weekStartDate: undefined })).toThrowError(/invalid weekStartDate/i);
-    expect(() => momentFromStruct({}, { weekStartDate: null })).toThrowError(/invalid weekStartDate/i);
-    expect(() => momentFromStruct({}, {})).toThrowError(/invalid weekStartDate/i);
-    expect(() => momentFromStruct({}, { weekStartDate: -1 })).toThrowError(/invalid weekStartDate/i);
-    expect(() => momentFromStruct({}, { weekStartDate: 7 })).toThrowError(/invalid weekStartDate/i);
+  it('validates weekStartDay', () => {
+    expect(() => momentFromStruct({}, { weekStartDay: undefined })).toThrowError(/invalid weekStartDay/i);
+    expect(() => momentFromStruct({}, { weekStartDay: null })).toThrowError(/invalid weekStartDay/i);
+    expect(() => momentFromStruct({}, {})).toThrowError(/invalid weekStartDay/i);
+    expect(() => momentFromStruct({}, { weekStartDay: -1 })).toThrowError(/invalid weekStartDay/i);
+    expect(() => momentFromStruct({}, { weekStartDay: 7 })).toThrowError(/invalid weekStartDay/i);
   });
 });

--- a/packages/date-parser/src/index.js
+++ b/packages/date-parser/src/index.js
@@ -67,10 +67,10 @@ const getParsedResultBoundaries = (parsedResults) => {
  * @param {Object} options
  * @param {Number} options.timezoneOffset Timezone offset in minutes
  * @param {OUTPUT_TYPES} options.output Type of the output dates
- * @param {Number} weekStartDate The weekday chosen to be the start of a week. See WEEKDAYS constant for possible values
+ * @param {Number} weekStartDay The weekday chosen to be the start of a week. See WEEKDAYS constant for possible values
  * @return {ChronoNode.ParsedResult|Array}
  */
-export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component, weekStartDate = WEEKDAYS.Monday } = {}) => {
+export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component, weekStartDay = WEEKDAYS.Monday } = {}) => {
   const refDate = new Date(ref);
   if (!isValidDate(refDate)) throw new InputError(`Invalid reference date: ${ref}`);
 
@@ -78,9 +78,9 @@ export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.pars
   timezoneOffset = parseInt(timezoneOffset);
   if (Number.isNaN(timezoneOffset)) throw new InputError(`Invalid timezoneOffset: ${timezoneOffset}`);
 
-  if (!(weekStartDate in WEEKDAYS_MAP)) throw new InputError(`Invalid weekStartDate: ${weekStartDate}. See exported constant WEEKDAYS for valid values`);
+  if (!(weekStartDay in WEEKDAYS_MAP)) throw new InputError(`Invalid weekStartDay: ${weekStartDay}. See exported constant WEEKDAYS for valid values`);
   /* eslint-disable-next-line no-param-reassign */
-  weekStartDate = WEEKDAYS_MAP[weekStartDate];
+  weekStartDay = WEEKDAYS_MAP[weekStartDay];
 
   // Adjust refDate by timezoneOffset
   let refMoment = dayjs.utc(refDate);
@@ -91,7 +91,7 @@ export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.pars
   const { parts, rangeSeparator } = splittedInput;
   let { isRange, isRangeEndInclusive } = splittedInput;
 
-  const parsedResults = _compact(parts.map(part => chrono.parse(part, refDateAdjustedByTz, { timezoneOffset, weekStartDate })[0]));
+  const parsedResults = _compact(parts.map(part => chrono.parse(part, refDateAdjustedByTz, { timezoneOffset, weekStartDay })[0]));
 
   if (output === OUTPUT_TYPES.raw) return parsedResults;
 

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -1078,10 +1078,10 @@ describe('dateParser', () => {
     expect(() => parse('thursday', new Date())).toThrowError(/ambiguous.*thursday last\/this\/next week/);
   });
 
-  it('works with weekStartDate', () => {
+  it('works with weekStartDay', () => {
     let res;
 
-    res = parse('last week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('last week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1099,7 +1099,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-18T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
 
-    res = parse('last 2 weeks', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('last 2 weeks', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1117,7 +1117,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-11T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
 
-    res = parse('2 weeks from now', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('2 weeks from now', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1135,7 +1135,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-09T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-16T00:00:00.000Z');
 
-    res = parse('this week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('this week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1154,7 +1154,7 @@ describe('dateParser', () => {
     expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
 
     // This test to make sure the WSD does not effect last month
-    res = parse('last 2 month', new Date('2019-02-09T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('last 2 month', new Date('2019-02-09T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1173,7 +1173,7 @@ describe('dateParser', () => {
     expect(res.end.date().toISOString()).toEqual('2019-02-01T00:00:00.000Z');
 
     // This test to make sure the WSD does not effect the last year
-    res = parse('last year', new Date('2020-02-29T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('last year', new Date('2020-02-29T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1191,7 +1191,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-01-01T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-01T00:00:00.000Z');
 
-    res = parse('tue last week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('tue last week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1209,7 +1209,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-24T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-25T00:00:00.000Z');
 
-    res = parse('tue next 2 weeks', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Wednesday });
+    res = parse('tue next 2 weeks', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Wednesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1227,7 +1227,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-14T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-15T00:00:00.000Z');
 
-    res = parse('mon next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Sunday });
+    res = parse('mon next week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Sunday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1245,7 +1245,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-30T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-31T00:00:00.000Z');
 
-    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Sunday });
+    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Sunday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1263,7 +1263,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-04T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-05T00:00:00.000Z');
 
-    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Saturday });
+    res = parse('sat next week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Saturday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1281,7 +1281,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-28T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-29T00:00:00.000Z');
 
-    res = parse('thu next week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Thursday });
+    res = parse('thu next week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Thursday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1299,7 +1299,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2020-01-02T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2020-01-03T00:00:00.000Z');
 
-    res = parse('thu last week', new Date('2019-12-26T02:14:05Z'), { weekStartDate: WEEKDAYS.Friday });
+    res = parse('thu last week', new Date('2019-12-26T02:14:05Z'), { weekStartDay: WEEKDAYS.Friday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1317,7 +1317,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2019-12-19T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2019-12-20T00:00:00.000Z');
 
-    res = parse('last week begin', new Date('2021-05-10T22:14:05Z'), { weekStartDate: WEEKDAYS.Tuesday });
+    res = parse('last week begin', new Date('2021-05-10T22:14:05Z'), { weekStartDay: WEEKDAYS.Tuesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1335,7 +1335,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2021-04-27T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2021-04-28T00:00:00.000Z');
 
-    res = parse('last week end', new Date('2021-05-10T22:14:05Z'), { weekStartDate: WEEKDAYS.Tuesday });
+    res = parse('last week end', new Date('2021-05-10T22:14:05Z'), { weekStartDay: WEEKDAYS.Tuesday });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1353,7 +1353,7 @@ describe('dateParser', () => {
     expect(res.start.date().toISOString()).toEqual('2021-05-03T00:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2021-05-04T00:00:00.000Z');
 
-    res = parse('last week end', new Date('2021-05-10T22:14:05Z'), { weekStartDate: WEEKDAYS.Tuesday, timezoneOffset: 480 });
+    res = parse('last week end', new Date('2021-05-10T22:14:05Z'), { weekStartDay: WEEKDAYS.Tuesday, timezoneOffset: 480 });
     expect(res).toMatchObject({
       start: {
         knownValues: {
@@ -1372,7 +1372,7 @@ describe('dateParser', () => {
     expect(res.end.date().toISOString()).toEqual('2021-05-10T16:00:00.000Z');
   });
 
-  it('raises error when weekStartDate is invalid', () => {
-    expect(() => parse('this mon', new Date(), { weekStartDate: 'ahihi' })).toThrowError(/invalid weekStartDate/i);
+  it('raises error when weekStartDay is invalid', () => {
+    expect(() => parse('this mon', new Date(), { weekStartDay: 'ahihi' })).toThrowError(/invalid weekStartDay/i);
   });
 });

--- a/packages/date-parser/src/parsers/lastX.js
+++ b/packages/date-parser/src/parsers/lastX.js
@@ -18,14 +18,14 @@ parser.pattern = () => {
  * @param {Object} opt
  */
 parser.extract = (text, ref, match, opt) => {
-  const { weekStartDate } = opt;
+  const { weekStartDay } = opt;
   const modifier = match[1];
   const value = modifier === 'this' ? 0 : parseInt((match[2] || '1').trim());
   const dateUnit = match[3].toLowerCase();
   const pointOfTime = (match[4] || '').trim();
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), dateUnit);
-  let startMoment = momentFromStruct(refDateStruct, { weekStartDate });
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDay });
   let endMoment = startMoment.clone();
 
   // Set range according to past/future relativity

--- a/packages/date-parser/src/parsers/today.js
+++ b/packages/date-parser/src/parsers/today.js
@@ -25,7 +25,7 @@ parser.extract = (text, ref, match, opt) => {
   }
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), 'day');
-  let startMoment = momentFromStruct(refDateStruct, { weekStartDate: opt.weekStartDate });
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDay: opt.weekStartDay });
   startMoment = startMoment.add(value, 'day');
 
   const endMoment = startMoment.add(1, 'day');

--- a/packages/date-parser/src/parsers/weekday.js
+++ b/packages/date-parser/src/parsers/weekday.js
@@ -19,7 +19,7 @@ parser.pattern = () => {
  * @param {Object} opt
  */
 parser.extract = (text, ref, match, opt) => {
-  const { weekStartDate } = opt;
+  const { weekStartDay } = opt;
   const weekday = match[1].toLowerCase();
   const modifier = match[2];
   let value;
@@ -32,9 +32,9 @@ parser.extract = (text, ref, match, opt) => {
   }
 
   const refDateStruct = truncateDateStruct(dateStructFromDate(ref), 'day');
-  let startMoment = momentFromStruct(refDateStruct, { weekStartDate });
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDay });
   startMoment = startMoment.add(value, 'week');
-  startMoment = startMoment.weekday((7 + WEEKDAYS_MAP[weekday] - weekStartDate) % 7);
+  startMoment = startMoment.weekday((7 + WEEKDAYS_MAP[weekday] - weekStartDay) % 7);
 
   const endMoment = startMoment.add(1, 'day');
 

--- a/packages/date-parser/src/parsers/xAgo.js
+++ b/packages/date-parser/src/parsers/xAgo.js
@@ -27,7 +27,7 @@ parser.extract = (text, ref, match, opt) => {
   if (!exact) {
     refDateStruct = truncateDateStruct(refDateStruct, dateUnit);
   }
-  let startMoment = momentFromStruct(refDateStruct, { weekStartDate: opt.weekStartDate });
+  let startMoment = momentFromStruct(refDateStruct, { weekStartDay: opt.weekStartDay });
   startMoment = startMoment.add(value, dateUnit);
 
   let endMoment = startMoment.clone();


### PR DESCRIPTION
## Summary
chore!: rename weekStartDate to weekStartDay

`date` should refer to an exact calendar date

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Breaking change
If this is a breaking change, state the changes.

## Checklist

Please check directly on the box once each of these are done

- [ ] Update CHANGELOG.md
- [ ] Code Review
