### PR TITLE
Fix various bugs on V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lerna:publish": "yarn test && lerna publish",
     "lerna:version": "yarn test && lerna version --conventional-commits",
     "lint": "eslint --ext .js --ignore-path .gitignore .",
-    "test": "env TZ='Asia/Singapore' jest"
+    "test": "env TZ='Asia/Singapore' LC_ALL='de-De' jest"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.7",

--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -5,6 +5,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
 
+**Note:** Version bump only for package @holistics/date-parser
+
+
+
+
+
+## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
+
 ### Bug Fixes
 
 https://github.com/holistics/js/pull/15

--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -5,10 +5,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
 
-**Note:** Version bump only for package @holistics/date-parser
+### Bug Fixes
 
-
-
+https://github.com/holistics/js/pull/15
+* Bug 1: doesn't handle null result
+* Bug 2: Inconsistent behavior of { zone } options in the browser. When calling with fromISO the zone is set to the DateTime instance, but when calling with fromObject the system zone (browser's zone) is used. This could be a bug of Luxon
+* Bug 3: using weekdayLong is affected by locale, switch to use index
 
 
 # [3.0.0](https://github.com/holistics/js/compare/@holistics/date-parser@2.9.0...@holistics/date-parser@3.0.0) (2021-10-29)

--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.2](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.2) (2021-11-05)
+
+**Note:** Version bump only for package @holistics/date-parser
+
+
+
+
+
 ## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.1...@holistics/date-parser@3.0.1) (2021-11-05)
 
 **Note:** Version bump only for package @holistics/date-parser

--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -3,22 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.0.2](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.2) (2021-11-05)
-
-**Note:** Version bump only for package @holistics/date-parser
-
-
-
-
-
-## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.1...@holistics/date-parser@3.0.1) (2021-11-05)
-
-**Note:** Version bump only for package @holistics/date-parser
-
-
-
-
-
 ## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
 
 ### Bug Fixes

--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -5,14 +5,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
 
-**Note:** Version bump only for package @holistics/date-parser
-
-
-
-
-
-## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
-
 ### Bug Fixes
 
 https://github.com/holistics/js/pull/15

--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.1...@holistics/date-parser@3.0.1) (2021-11-05)
+
+**Note:** Version bump only for package @holistics/date-parser
+
+
+
+
+
 ## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
 
 ### Bug Fixes

--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.1](https://github.com/holistics/js/compare/@holistics/date-parser@3.0.0...@holistics/date-parser@3.0.1) (2021-11-05)
+
+**Note:** Version bump only for package @holistics/date-parser
+
+
+
+
+
 # [3.0.0](https://github.com/holistics/js/compare/@holistics/date-parser@2.9.0...@holistics/date-parser@3.0.0) (2021-10-29)
 ### Features
 * V3 date parser including

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "3.0.2",
+  "version": "3.0.0",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/src/dateParserV3.js
+++ b/packages/date-parser/src/dateParserV3.js
@@ -128,6 +128,8 @@ export const parse = (str, ref, {
    */
   const result = buildResult(parsedResults, str, jsRefDate, weekStartDay);
 
+  if (!result) { return null; }
+
   switch (output) {
     case OUTPUT_TYPES.date:
       return result.asDate();

--- a/packages/date-parser/src/dateParserV3.test.js
+++ b/packages/date-parser/src/dateParserV3.test.js
@@ -484,6 +484,7 @@ describe('Parsing logic', () => {
 
   it('invalid text', () => {
     parse('meomeo', new Date(), { ...defaultOpts, timezoneRegion: 'Asia/Singapore' });
+    parse('last', new Date(), { ...defaultOpts, output: 'timestamp', timezoneRegion: 'Asia/Singapore' });
   });
 
   it('reject when parsing invalid ISO date', () => {

--- a/packages/date-parser/src/dateParserV3.test.js
+++ b/packages/date-parser/src/dateParserV3.test.js
@@ -492,21 +492,6 @@ describe('Parsing logic', () => {
   });
 });
 
-describe('should not be affected by locale', () => {
-  const defaultOpts = { parserVersion: PARSER_VERSION_3, output: 'raw' };
-
-  it('run at de-De environment should work', () => {
-    const res = parse('last week', new Date('2021-11-03T14:00:00Z'), {
-      ...defaultOpts, weekStartDay: WEEKDAYS.Thursday, timezoneRegion: 'Europe/Berlin', output: 'timestamp',
-    });
-
-    expect(res.start).toEqual('2021-10-21T00:00:00.000+02:00');
-    expect(res.end).toEqual('2021-10-28T00:00:00.000+02:00');
-
-    jest.restoreAllMocks();
-  });
-});
-
 describe('output types', () => {
   const defaultOpts = { parserVersion: PARSER_VERSION_3 };
 

--- a/packages/date-parser/src/dateParserV3.test.js
+++ b/packages/date-parser/src/dateParserV3.test.js
@@ -492,6 +492,21 @@ describe('Parsing logic', () => {
   });
 });
 
+describe('should not be affected by locale', () => {
+  const defaultOpts = { parserVersion: PARSER_VERSION_3, output: 'raw' };
+
+  it('run at de-De environment should work', () => {
+    const res = parse('last week', new Date('2021-11-03T14:00:00Z'), {
+      ...defaultOpts, weekStartDay: WEEKDAYS.Thursday, timezoneRegion: 'Europe/Berlin', output: 'timestamp',
+    });
+
+    expect(res.start).toEqual('2021-10-21T00:00:00.000+02:00');
+    expect(res.end).toEqual('2021-10-28T00:00:00.000+02:00');
+
+    jest.restoreAllMocks();
+  });
+});
+
 describe('output types', () => {
   const defaultOpts = { parserVersion: PARSER_VERSION_3 };
 

--- a/packages/date-parser/src/helpers/luxonFromChronoStruct.js
+++ b/packages/date-parser/src/helpers/luxonFromChronoStruct.js
@@ -1,5 +1,4 @@
-import { DateTime } from 'luxon';
-import { ParseError } from '../errors';
+import luxonFromStruct from './luxonFromStruct';
 
 /**
  *
@@ -7,7 +6,7 @@ import { ParseError } from '../errors';
  * @returns {Luxon.DateTime}
  */
 const luxonFromChronoStruct = (chronoStruct) => {
-  const datetime = DateTime.fromObject({
+  return luxonFromStruct({
     year: chronoStruct.get('year'),
     month: chronoStruct.get('month'),
     day: chronoStruct.get('day'),
@@ -15,15 +14,8 @@ const luxonFromChronoStruct = (chronoStruct) => {
     minute: chronoStruct.get('minute'),
     second: chronoStruct.get('second'),
     millisecond: chronoStruct.get('millisecond'),
-  }, {
-    zone: chronoStruct.get('timezone'),
+    timezone: chronoStruct.get('timezone'),
   });
-
-  if (!datetime.isValid) {
-    throw new ParseError(`${datetime.invalidReason}: ${datetime.invalidExplanation}`);
-  }
-
-  return datetime;
 };
 
 export default luxonFromChronoStruct;

--- a/packages/date-parser/src/helpers/luxonFromStruct.js
+++ b/packages/date-parser/src/helpers/luxonFromStruct.js
@@ -4,21 +4,19 @@ import { ParseError } from '../errors';
 export default ({
   year, month, day, hour, minute, second, millisecond, timezone,
 }) => {
-  const datetime = DateTime.fromObject({
+  const datetime = DateTime.utc(
     year,
-    month, // luxon's month starts at 1, same as our date struct
+    month,
     day,
     hour,
     minute,
     second,
     millisecond,
-  }, {
-    zone: timezone,
-  });
+  );
 
   if (!datetime.isValid) {
     throw new ParseError(`${datetime.invalidReason}: ${datetime.invalidExplanation}`);
   }
 
-  return datetime;
+  return datetime.setZone(timezone, { keepLocalTime: true });
 };

--- a/packages/date-parser/src/helpers/luxonFromStruct.js
+++ b/packages/date-parser/src/helpers/luxonFromStruct.js
@@ -4,6 +4,8 @@ import { ParseError } from '../errors';
 export default ({
   year, month, day, hour, minute, second, millisecond, timezone,
 }) => {
+  // Warning: don't use fromObject here because its behavior is inconsistent in the browser
+  // See https://github.com/holistics/js/pull/15
   const datetime = DateTime.utc(
     year,
     month,

--- a/packages/date-parser/src/helpers/startEndOfCustom.js
+++ b/packages/date-parser/src/helpers/startEndOfCustom.js
@@ -1,5 +1,5 @@
-import { lowerCase } from 'lodash';
 import { WEEKDAYS_MAP } from '../constants';
+import weekdayIdxFromLuxon from './weekdayIdxFromLuxon';
 
 /**
  *
@@ -8,7 +8,7 @@ import { WEEKDAYS_MAP } from '../constants';
  * @returns number
  */
 const shiftRange = (currentDate, wsdIdx) => {
-  const currentWeekday = WEEKDAYS_MAP[lowerCase(currentDate.weekdayLong)];
+  const currentWeekday = weekdayIdxFromLuxon(currentDate);
   return (currentWeekday - wsdIdx + 7) % 7;
 };
 

--- a/packages/date-parser/src/helpers/weekdayIdxFromLuxon.js
+++ b/packages/date-parser/src/helpers/weekdayIdxFromLuxon.js
@@ -1,6 +1,6 @@
 const weekdayIdxFromLuxon = (luxon) => {
   const idx = luxon.weekday;
-  return idx === 7 ? 0 : idx; // our Sunday starts at 0, while Luxon is 7
+  return idx === 7 ? 0 : idx; // our Sunday is 0, while Luxon is 7
 };
 
 export default weekdayIdxFromLuxon;

--- a/packages/date-parser/src/helpers/weekdayIdxFromLuxon.js
+++ b/packages/date-parser/src/helpers/weekdayIdxFromLuxon.js
@@ -1,0 +1,6 @@
+const weekdayIdxFromLuxon = (luxon) => {
+  const idx = luxon.weekday;
+  return idx === 7 ? 0 : idx; // our Sunday starts at 0, while Luxon is 7
+};
+
+export default weekdayIdxFromLuxon;

--- a/packages/date-parser/src/parsers/v3/weekday.js
+++ b/packages/date-parser/src/parsers/v3/weekday.js
@@ -1,16 +1,16 @@
 import Chrono from 'chrono-node';
-import { lowerCase } from 'lodash';
 import truncateDateStruct from '../../helpers/truncateDateStruct';
 import pluralize from '../../helpers/pluralize';
 import { WEEKDAYS_MAP } from '../../constants';
 import dateStructFromLuxon from '../../helpers/dateStructFromLuxon';
 import luxonFromStruct from '../../helpers/luxonFromStruct';
 import { startOfCustom } from '../../helpers/startEndOfCustom';
+import weekdayIdxFromLuxon from '../../helpers/weekdayIdxFromLuxon';
 
 const parser = new Chrono.Parser();
 
 const daysBetweeen = (startOfWeek, weekday) => {
-  const fromWeekdayIdx = WEEKDAYS_MAP[lowerCase(startOfWeek.weekdayLong)];
+  const fromWeekdayIdx = weekdayIdxFromLuxon(startOfWeek);
   const toWeekdayIdx = WEEKDAYS_MAP[weekday];
 
   if (fromWeekdayIdx <= toWeekdayIdx) { return toWeekdayIdx - fromWeekdayIdx; }


### PR DESCRIPTION
## Summary
* Bug 1: doesn't handle `null` result

* Bug 2: Inconsistent behavior of `{ zone }` options **in the browser**. When calling with `fromISO` the zone is set to the DateTime instance, but when calling with `fromObject` the system zone (browser's zone) is used. This could be a bug of Luxon

![image](https://user-images.githubusercontent.com/11194590/140259474-12f62773-9e59-4511-bf47-3f76677d04a2.png)

**Note:** This doesn't happen if using NodeJS but it happens the browser

Fix by using `utc` and `setZone`

![image](https://user-images.githubusercontent.com/11194590/140451375-873cfa30-90e2-4665-a81f-ddb0e062b7d3.png)


* Bug 3: using `weekdayLong` is affected by locale, switch to use index

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Breaking change
If this is a breaking change, state the changes.

## Checklist

Please check directly on the box once each of these are done

- [x] Update CHANGELOG.md
- [ ] Code Review
