### PR TITLE
security(packages.date-parser): add limit check for date string

### DIFF
--- a/packages/date-parser/CHANGELOG.md
+++ b/packages/date-parser/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [3.3.0](https://github.com/holistics/js/compare/@holistics/date-parser@3.1.2...@holistics/date-parser@3.3.0) (2023-10-13)
+
+
+### Features
+
+* **yarn:** bump pkg from 4.4.2 to 5.8.1 ([b62bd8c](https://github.com/holistics/js/commit/b62bd8cfbb1436c6bcaefbae5789cb7594f99e98))
+
+
+
+
+
 # [3.2.0](https://github.com/holistics/js/compare/@holistics/date-parser@3.1.2...@holistics/date-parser@3.2.0) (2023-08-03)
 
 

--- a/packages/date-parser/package.json
+++ b/packages/date-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holistics/date-parser",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Date parser",
   "author": "Dat Bui <scott.bui@holistics.io>",
   "homepage": "https://github.com/holistics/js#readme",

--- a/packages/date-parser/src/constants.js
+++ b/packages/date-parser/src/constants.js
@@ -73,3 +73,4 @@ export const DATE_RANGE_PATTERNS = {
 
 export const PARSER_VERSION_1 = 1;
 export const PARSER_VERSION_3 = 3;
+export const DATE_STRING_CHARACTER_LIMIT = 200;

--- a/packages/date-parser/src/dateParserV1.js
+++ b/packages/date-parser/src/dateParserV1.js
@@ -19,6 +19,7 @@ import Errors, { InputError } from './errors';
 
 import splitInputStr from './helpers/splitInputString';
 import getParsedResultBoundaries from './helpers/getParsedResultBoundaries';
+import exceedLimit from './helpers/checkDateStringCharacterLimit';
 
 const chrono = new ChronoNode.Chrono(options);
 
@@ -35,6 +36,7 @@ const chrono = new ChronoNode.Chrono(options);
 export const parse = (str, ref, { timezoneOffset = 0, output = OUTPUT_TYPES.parsed_component, weekStartDay = WEEKDAYS.Monday } = {}) => {
   const refDate = new Date(ref);
   if (!isValidDate(refDate)) throw new InputError(`Invalid reference date: ${ref}`);
+  if (exceedLimit(str)) throw new InputError('Date value exceeds limit of 200 characters');
 
   /* eslint-disable-next-line no-param-reassign */
   timezoneOffset = parseInt(timezoneOffset);

--- a/packages/date-parser/src/dateParserV3.js
+++ b/packages/date-parser/src/dateParserV3.js
@@ -9,6 +9,7 @@ import isValidDate from './helpers/isValidDate';
 import TimezoneRegion from './helpers/timezoneRegion';
 import splitInputStr from './helpers/splitInputString';
 import getParsedResultBoundaries from './helpers/getParsedResultBoundaries';
+import exceedLimit from './helpers/checkDateStringCharacterLimit';
 import { InputError } from './errors';
 import {
   WEEKDAYS,
@@ -100,6 +101,8 @@ export const parse = (str, ref, {
   /**
    * Inputs parsing and validation
    */
+  if (exceedLimit(str)) throw new InputError('Date value exceeds limit of 200 characters');
+
   const { jsRefDate, wsday } = parseInputs(ref, weekStartDay);
   const zone = new TimezoneRegion(timezoneRegion);
   const { parts } = splitInputStr(str);

--- a/packages/date-parser/src/dateParserV3.test.js
+++ b/packages/date-parser/src/dateParserV3.test.js
@@ -1,11 +1,18 @@
 import {
   parse, WEEKDAYS,
 } from './index';
+import { InputError } from './errors';
 import { parse as parseV3 } from './dateParserV3';
 import { PARSER_VERSION_3 } from './constants';
 
 describe('Parsing logic', () => {
   const defaultOpts = { parserVersion: PARSER_VERSION_3, output: 'raw' };
+
+  it('throw error when exceed character limit', () => {
+    expect(() => {
+      parse(`last week${' '.repeat(1000)}`, new Date('2019-12-26T02:14:05Z'), defaultOpts);
+    }).toThrow(new InputError('Date value exceeds limit of 200 characters'));
+  });
 
   it('works with lastX format', () => {
     let res;

--- a/packages/date-parser/src/helpers/checkDateStringCharacterLimit.js
+++ b/packages/date-parser/src/helpers/checkDateStringCharacterLimit.js
@@ -1,0 +1,11 @@
+import { DATE_STRING_CHARACTER_LIMIT } from '../constants';
+
+/**
+ * @param {String} str A date string
+ * @return {Boolean}
+ */
+const exceedLimit = (str) => {
+  return str.length > DATE_STRING_CHARACTER_LIMIT;
+};
+
+export default exceedLimit;

--- a/packages/date-parser/src/index.test.js
+++ b/packages/date-parser/src/index.test.js
@@ -1,6 +1,7 @@
 import {
   parse, WEEKDAYS, OUTPUT_TYPES, Errors,
 } from './index';
+import { InputError } from './errors';
 import { parse as parseV1 } from './dateParserV1';
 
 describe('common tests', () => {
@@ -13,6 +14,12 @@ describe('common tests', () => {
 });
 
 describe('dateParser', () => {
+  it('throw error when exceed character limit', () => {
+    expect(() => {
+      parse(`last week${' '.repeat(1000)}`, new Date('2019-12-26T02:14:05Z'));
+    }).toThrow(new InputError('Date value exceeds limit of 200 characters'));
+  });
+
   it('works with lastX format', () => {
     let res;
 
@@ -1025,7 +1032,6 @@ describe('dateParser', () => {
     res = parse('next month end', '2018-01-01T05:00:00+08:00', { timezoneOffset: 180 });
     expect(res.start.date().toISOString()).toEqual('2018-02-27T21:00:00.000Z');
     expect(res.end.date().toISOString()).toEqual('2018-02-28T21:00:00.000Z');
-
 
     res = parse('yesterday', new Date('2019-04-11T23:00:00+00:00'), { timezoneOffset: 540 });
     expect(res.start.date().toISOString()).toEqual('2019-04-10T15:00:00.000Z');


### PR DESCRIPTION
## Summary
* Add limit check for date string values in parser V1 and V3 (200 characters)

## Task
https://app.asana.com/0/76997687380943/1205707671183365/f

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before)

## Breaking change
If this is a breaking change, state the changes.

## Checklist

Please check directly on the box once each of these are done

- [x] Update CHANGELOG.md
- [ ] Code Review
